### PR TITLE
Ajustes nos componentes do materials

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,26 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <meta name="theme-color" content="#000000" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <link
-      href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css"
-      rel="stylesheet"
-    />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/icon?family=Material+Icons"
-    />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
-    />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     <title>Asplenio</title>
   </head>
 

--- a/src/Asplenio.js
+++ b/src/Asplenio.js
@@ -12,56 +12,34 @@ import CardContent from '@material-ui/core/CardContent';
 import AppBar from '@material-ui/core/AppBar';
 import Button from '@material-ui/core/Button';
 import Container from "@material-ui/core/Container";
+import Grid from '@material-ui/core/Grid';
 
 class Asplenio extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <Container>
-          <header>
-            <AppBar position="static"></AppBar>
-
-            <header class="mdc-top-app-bar">
-              <div class="mdc-top-app-bar__row">
-                <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
-                  <span class="mdc-top-app-bar__title">Asplenio</span>
-                </section>
-                <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
-                  <span class="material-icons mdc-top-app-bar__action-item">
-                    thermostat
-                  </span>
-                  <Temperatura valor="28" />
-                </section>
-                <section
-                  class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end"
-                  role="toolbar"
-                >
-                  <span class="material-icons mdc-top-app-bar__action-item">
-                    location_on
-                  </span>
-                  <Typography>Videira</Typography>
-                </section>
-              </div>
-            </header>
-
-            <main class="mdc-top-app-bar--fixed-adjust"></main>
-          </header>
-          <div>
-            <Card classes="piscina ">
+        <AppBar position="static">
+          <Typography>Asplenio</Typography>
+          <span className="material-icons mdc-top-app-bar__action-item">location_on</span>
+          <Typography>Videira</Typography>
+          <span className="material-icons mdc-top-app-bar__action-item">thermostat</span>
+          <Temperatura valor="28" />
+        </AppBar>
+        <div>
+            <Card classeName="piscina ">
               <CardContent>
-                <span class="material-icons">hot_tub</span>
+                <span className="material-icons">hot_tub</span>
                 <Typography>Piscina</Typography>
                 <Typography>26°</Typography>
               </CardContent>
             </Card>
-            <Card classes="paineis">
+            <Card classeName="paineis">
               <CardContent>
-                <span class="material-icons">gite</span>
+                <span className="material-icons">gite</span>
                 <Typography>Painéis</Typography>
                 <Typography>26°</Typography>
               </CardContent>
             </Card>
-
             <h2>Temperatura desejada</h2>
             <Typography id="discrete-slider-always" gutterBottom>
               Escolha a Temperatura
@@ -87,15 +65,14 @@ class Asplenio extends React.Component {
               />
             </FormGroup>
           </div>
-
-          <Card classes="status">
+          <Card className="status">
             <CardContent>
-              <span class="material-icons">bolt</span>
+              <span className="material-icons">bolt</span>
               <Typography>Motor Ligado</Typography>
               <Button>DESLIGAR</Button>
             </CardContent>
           </Card>
-        </Container>
+      
       </React.Fragment>
     );
   }


### PR DESCRIPTION
### Problema
Eu havia utilizado alguns componentes do materials de forma errada, o que gerou um erro nos espaçamentos e dificultava os ajustes de responsividade que serão feitos em uma próxima etapa.

### Ações
Recriei o appbar para corrigir o problema dos espaçamentos;
Corrigi algumas classes para o nome 'className';
Removi links desnecessários agora que o materials está devidamente instalado.

### Resultado
Nada mudou muito visualmente.
O próximo passo é trabalhar com o grid do materials ou utilizar o grid do bootstrap para deixar os itens organizadinhos da tela :straight_ruler: